### PR TITLE
Fix incorrect encoding issue:

### DIFF
--- a/src/groovy/com/odobo/grails/plugin/springsecurity/rest/RestTokenValidationFilter.groovy
+++ b/src/groovy/com/odobo/grails/plugin/springsecurity/rest/RestTokenValidationFilter.groovy
@@ -53,9 +53,7 @@ class RestTokenValidationFilter extends GenericFilterBean {
                     log.debug "Authentication result: ${authenticationResult}"
                     SecurityContextHolder.context.setAuthentication(authenticationResult)
 
-                    authenticationSuccessHandler.onAuthenticationSuccess(request, response, authenticationResult)
-
-                    processFilterChain(request, response, chain, tokenValue)
+                    processFilterChain(request, response, chain, tokenValue, authenticationResult)
 
                 }
 
@@ -65,12 +63,12 @@ class RestTokenValidationFilter extends GenericFilterBean {
             }
         } else {
             log.debug "Token not found"
-            processFilterChain(request, response, chain, tokenValue)
+            processFilterChain(request, response, chain, tokenValue, null)
         }
 
     }
 
-    private processFilterChain(ServletRequest request, ServletResponse response, FilterChain chain, String tokenValue) {
+    private processFilterChain(ServletRequest request, ServletResponse response, FilterChain chain, String tokenValue, RestAuthenticationToken authenticationResult) {
         HttpServletRequest servletRequest = request
 
         def actualUri =  servletRequest.requestURI - servletRequest.contextPath
@@ -82,6 +80,8 @@ class RestTokenValidationFilter extends GenericFilterBean {
                 HttpServletResponse servletResponse = response
                 log.debug "Token header is missing. Sending a 400 Bad Request response"
                 servletResponse.sendError HttpServletResponse.SC_BAD_REQUEST, "Token header is missing"
+            } else {
+                authenticationSuccessHandler.onAuthenticationSuccess(request, response, authenticationResult)
             }
         } else {
             log.debug "Continuing the filter chain"


### PR DESCRIPTION
Output to response by authenticationSuccessHandler make character encoding fix to ISO-8859-1.
# Test case

I 'm setup a TestController. 
https://gist.github.com/pphetra/9084508

When api called without token. The encoding is 'UTF-8'
![screen shot 2557-02-19 at 8 29 29 am](https://f.cloud.github.com/assets/1422/2202576/6393706e-9906-11e3-917d-d27771dd9d0c.png)

When api called with token. The encoding is change to ISO-8859-1
![screen shot 2557-02-19 at 8 30 52 am](https://f.cloud.github.com/assets/1422/2202582/86428fb4-9906-11e3-8e9f-a09d4fa0f936.png)
