### PR TITLE
Token response customization

### DIFF
--- a/grails-app/conf/DefaultRestSecurityConfig.groovy
+++ b/grails-app/conf/DefaultRestSecurityConfig.groovy
@@ -19,6 +19,12 @@ security {
 
         }
 
+        response {
+            usernamePropertyName = 'username'
+            tokenPropertyName = 'token'
+            authoritiesPropertyName = 'roles'
+        }
+
         logout {
 
             endpointUrl = '/api/logout'

--- a/src/groovy/com/odobo/grails/plugin/springsecurity/rest/token/rendering/DefaultRestAuthenticationTokenJsonRenderer.groovy
+++ b/src/groovy/com/odobo/grails/plugin/springsecurity/rest/token/rendering/DefaultRestAuthenticationTokenJsonRenderer.groovy
@@ -1,5 +1,6 @@
 package com.odobo.grails.plugin.springsecurity.rest.token.rendering
 
+import grails.plugin.springsecurity.SpringSecurityUtils
 import com.odobo.grails.plugin.springsecurity.rest.RestAuthenticationToken
 import grails.converters.JSON
 import groovy.util.logging.Slf4j
@@ -17,10 +18,16 @@ class DefaultRestAuthenticationTokenJsonRenderer implements RestAuthenticationTo
         Assert.isInstanceOf(UserDetails, restAuthenticationToken.principal, "A UserDetails implementation is required")
         UserDetails userDetails = restAuthenticationToken.principal
 
-        def result = [
-            username: userDetails.username,
-            token: restAuthenticationToken.tokenValue,
-            roles: userDetails.authorities.collect {GrantedAuthority role -> role.authority }]
+        def conf = SpringSecurityUtils.securityConfig
+
+        String usernameProperty = conf.rest.response.usernamePropertyName
+        String tokenProperty = conf.rest.response.tokenPropertyName
+        String authoritiesProperty = conf.rest.response.authoritiesPropertyName
+
+        def result = [:]
+        result["$usernameProperty"] = userDetails.username
+        result["$tokenProperty"] = restAuthenticationToken.tokenValue
+        result["$authoritiesProperty"] = userDetails.authorities.collect {GrantedAuthority role -> role.authority }
 
         def jsonResult = result as JSON
 

--- a/test/unit/com/odobo/grails/plugin/springsecurity/rest/token/rendering/DefaultRestAuthenticationTokenJsonRendererSpec.groovy
+++ b/test/unit/com/odobo/grails/plugin/springsecurity/rest/token/rendering/DefaultRestAuthenticationTokenJsonRendererSpec.groovy
@@ -5,15 +5,26 @@ import grails.test.mixin.TestMixin
 import grails.test.mixin.web.ControllerUnitTestMixin
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.User
+import org.codehaus.groovy.grails.commons.GrailsApplication
+import grails.plugin.springsecurity.ReflectionUtils
+import grails.plugin.springsecurity.SpringSecurityUtils
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
 @TestMixin(ControllerUnitTestMixin)
 class DefaultRestAuthenticationTokenJsonRendererSpec extends Specification {
+    def config
+    def setup(){
+        def application = Mock(GrailsApplication)
+        config = new ConfigObject()
+        application.getConfig() >> config
+        ReflectionUtils.application = application
+        SpringSecurityUtils.loadSecondaryConfig 'DefaultRestSecurityConfig'
+    }
 
     @Unroll
-	void "it renders proper JSON for a given token when the user has #roles.size() roles"() {
+    void "it renders proper JSON for a given token when the user has #roles.size() roles"() {
         given:
         def username = 'john.doe'
         def password = 'donttellanybody'
@@ -34,7 +45,36 @@ class DefaultRestAuthenticationTokenJsonRendererSpec extends Specification {
         roles                                                                       | generatedJson
         [new SimpleGrantedAuthority('USER'), new SimpleGrantedAuthority('ADMIN')]   | '{"username":"john.doe","token":"1a2b3c4d","roles":["ADMIN","USER"]}'
         []                                                                          | '{"username":"john.doe","token":"1a2b3c4d","roles":[]}'
-	}
+    }
+
+    void "Render json with custom properties"() {
+        given:
+        def username = 'john.doe'
+        def password = 'donttellanybody'
+        def tokenValue = '1a2b3c4d'
+        def userDetails = new User(username, password, roles)
+
+        RestAuthenticationToken token = new RestAuthenticationToken(userDetails, password, roles, tokenValue)
+
+        DefaultRestAuthenticationTokenJsonRenderer renderer = new DefaultRestAuthenticationTokenJsonRenderer()
+
+        and: "Spring security configuration"
+        SpringSecurityUtils.securityConfig.rest.response.usernamePropertyName = "login"
+        SpringSecurityUtils.securityConfig.rest.response.tokenPropertyName = "access_token"
+        SpringSecurityUtils.securityConfig.rest.response.authoritiesPropertyName = "authorities"
+
+        when:
+        def jsonResult = renderer.generateJson(token)
+
+        then:
+        jsonResult == generatedJson
+
+        where:
+        roles                                                                       | generatedJson
+        [new SimpleGrantedAuthority('USER'), new SimpleGrantedAuthority('ADMIN')]   | '{"login":"john.doe","access_token":"1a2b3c4d","authorities":["ADMIN","USER"]}'
+        []                                                                          | '{"login":"john.doe","access_token":"1a2b3c4d","authorities":[]}'
+    }
+
 
     @Issue('https://github.com/alvarosanchez/grails-spring-security-rest/issues/18')
     void "it checks if the principal is a UserDetails"() {
@@ -50,6 +90,4 @@ class DefaultRestAuthenticationTokenJsonRendererSpec extends Specification {
         then:
         thrown IllegalArgumentException
     }
-
-
 }


### PR DESCRIPTION
I've added a new configuration to customize the response generated on the "DefaultRestAuthenticationTokenJsonRenderer".

The properties are:

grails.plugin.springsecurity.rest.response.usernamePropertyName
grails.plugin.springsecurity.rest.response.tokenPropertyName
grails.plugin.springsecurity.rest.response.authoritiesPropertyName
