### PR TITLE
If request does not contain correct authentication, then use authentication already in SecurityContext.

### DIFF
--- a/src/groovy/com/odobo/grails/plugin/springsecurity/rest/RestAuthenticationFilter.groovy
+++ b/src/groovy/com/odobo/grails/plugin/springsecurity/rest/RestAuthenticationFilter.groovy
@@ -82,17 +82,18 @@ class RestAuthenticationFilter extends GenericFilterBean {
                 try {
                     log.debug "Trying to authenticate the request"
                     authenticationResult = authenticationManager.authenticate(authenticationRequest)
+              
+                    if (authenticationResult.authenticated) {
+                        log.debug "Request authenticated. Storing the authentication result in the security context"
+                        log.debug "Authentication result: ${authenticationResult}"
+    
+                        SecurityContextHolder.context.setAuthentication(authenticationResult)
+                    }
                 } catch (AuthenticationException ae) {
                     log.debug "Authentication failed: ${ae.message}"
                     authenticationFailureHandler.onAuthenticationFailure(httpServletRequest, httpServletResponse, ae)
                 }
-                
-                if (authenticationResult.authenticated) {
-                    log.debug "Request authenticated. Storing the authentication result in the security context"
-                    log.debug "Authentication result: ${authenticationResult}"
-
-                    SecurityContextHolder.context.setAuthentication(authenticationResult)
-                }
+            
             }else{
                 log.debug "Username and/or password parameters are missing."
                 if(!authentication){
@@ -105,7 +106,7 @@ class RestAuthenticationFilter extends GenericFilterBean {
                 }
             }
 
-            if (authenticationResult.authenticated) {
+            if (authenticationResult?.authenticated) {
                 String tokenValue = tokenGenerator.generateToken()
                 log.debug "Generated token: ${tokenValue}"
 


### PR DESCRIPTION
It makes possible to use spring-security-cas plugin to login to application.

When main page is reached, then user is redirected to CAS to login. After succesful login, user is redirected back on main page, where ajax post request is made to /rest/login ( without username/password). And returned token is added to ajax headers.

Config.groovy:

String restFilters = 'JOINED_FILTERS,-casAuthenticationFilter,-exceptionTranslationFilter,-authenticationProcessingFilter,-securityContextPersistenceFilter'
String casFilters = 'JOINED_FILTERS,-restTokenValidationFilter,-restExceptionTranslationFilter'  
grails.plugin.springsecurity.filterChain.chainMap = [
    '/rest/login': 'JOINED_FILTERS',
    '/index.gsp': casFilters,
    '/j_spring_cas_security_check': casFilters,
    '/**': restFilters
]
