### PR TITLE
Fixes the "java.lang.IllegalStateException: Cannot forward after respons...

### DIFF
--- a/SpringSecurityRestGrailsPlugin.groovy
+++ b/SpringSecurityRestGrailsPlugin.groovy
@@ -119,7 +119,9 @@ class SpringSecurityRestGrailsPlugin {
 
         if( conf.rest.token.validation.useBearerToken ) {
             tokenReader(BearerTokenReader)
-            restAuthenticationFailureHandler(BearerTokenAuthenticationFailureHandler)
+            restAuthenticationFailureHandler(BearerTokenAuthenticationFailureHandler){
+                tokenReader = ref('tokenReader')
+            }
             restAuthenticationEntryPoint(BearerTokenAuthenticationEntryPoint) {
                 tokenReader = ref('tokenReader')
             }

--- a/src/groovy/com/odobo/grails/plugin/springsecurity/rest/token/bearer/BearerTokenAuthenticationFailureHandler.groovy
+++ b/src/groovy/com/odobo/grails/plugin/springsecurity/rest/token/bearer/BearerTokenAuthenticationFailureHandler.groovy
@@ -1,8 +1,7 @@
 package com.odobo.grails.plugin.springsecurity.rest.token.bearer
 
-import com.odobo.grails.plugin.springsecurity.rest.token.storage.TokenNotFoundException
+import com.odobo.grails.plugin.springsecurity.rest.token.reader.TokenReader
 import groovy.util.logging.Slf4j
-import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.web.authentication.AuthenticationFailureHandler
 
@@ -16,6 +15,8 @@ import javax.servlet.http.HttpServletResponse
 @Slf4j
 class BearerTokenAuthenticationFailureHandler implements AuthenticationFailureHandler {
 
+    TokenReader tokenReader
+
     /**
      * Sends the proper response code and headers, as defined by RFC6750.
      *
@@ -28,25 +29,27 @@ class BearerTokenAuthenticationFailureHandler implements AuthenticationFailureHa
     @Override
     void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException e) throws IOException, ServletException {
 
-        if (!response.containsHeader('WWW-Authenticate')) {
-            String headerValue
+        String headerValue
+        int status
+        def token = tokenReader.findToken(request, response)
+        def matchesBearerSpecPreconditions = tokenReader.matchesBearerSpecPreconditions(request, response)
 
-            //response code is determined by authentication failure reason
-            if(e instanceof TokenNotFoundException) {
-                //The user supplied credentials, but they did not match an account,
-                // or there was an underlying authentication issue.
-                headerValue = 'Bearer error="invalid_token"'
-            } else {
-                //no credentials were provided.  Add no additional information
-                headerValue = 'Bearer'
-            }
-
-            response.addHeader('WWW-Authenticate', headerValue)
+        if (token && !matchesBearerSpecPreconditions) {
+            headerValue = 'Bearer error="invalid_token"'
+            status = HttpServletResponse.SC_UNAUTHORIZED
+        } else if (!token && matchesBearerSpecPreconditions) {
+            headerValue = 'Bearer '
+            status = HttpServletResponse.SC_UNAUTHORIZED
+        } else if(token && matchesBearerSpecPreconditions) {
+            headerValue = 'Bearer error="invalid_token"'
+            status = HttpServletResponse.SC_UNAUTHORIZED
+        }else if (!token && !matchesBearerSpecPreconditions) {
+            headerValue = 'Bearer error="invalid_request"'
+            status = HttpServletResponse.SC_BAD_REQUEST
         }
 
-        if (response.status == 200) {
-            response.status = 401
-        }
+        response.addHeader('WWW-Authenticate', headerValue)
+        response.status = status
 
         log.debug "Sending status code ${response.status} and header WWW-Authenticate: ${response.getHeader('WWW-Authenticate')}"
     }

--- a/src/groovy/com/odobo/grails/plugin/springsecurity/rest/token/bearer/BearerTokenReader.groovy
+++ b/src/groovy/com/odobo/grails/plugin/springsecurity/rest/token/bearer/BearerTokenReader.groovy
@@ -42,10 +42,12 @@ class BearerTokenReader implements TokenReader {
      * @param servletResponse
      * @return
      */
-    private boolean matchesBearerSpecPreconditions(HttpServletRequest servletRequest, HttpServletResponse servletResponse) {
+    public boolean matchesBearerSpecPreconditions(HttpServletRequest servletRequest, HttpServletResponse servletResponse) {
         boolean matches = true
         String message = ''
-        if (!servletRequest.contentType || !MediaType.parseMediaType(servletRequest.contentType).isCompatibleWith(MediaType.APPLICATION_FORM_URLENCODED)) {
+
+        def isFormEncoded = servletRequest.contentType && MediaType.parseMediaType(servletRequest.contentType).isCompatibleWith(MediaType.APPLICATION_FORM_URLENCODED)
+        if (!isFormEncoded) {
             log.debug "Invalid Content-Type: '${servletRequest.contentType}'. 'application/x-www-form-urlencoded' is mandatory"
             message = "Content-Type 'application/x-www-form-urlencoded' is mandatory when sending form-encoded body parameter requests with the access token (RFC 6750)"
             matches = false
@@ -58,22 +60,7 @@ class BearerTokenReader implements TokenReader {
             message = "GET HTTP method must not be used when sending form-encoded body parameter requests with the access token (RFC 6750)"
             matches = false
         }
-        if (!matches) {
-            servletResponse.addHeader('WWW-Authenticate', 'Bearer error="invalid_request"')
-            servletResponse.sendError HttpServletResponse.SC_BAD_REQUEST, message
-        }
-        return matches
-    }
 
-    /**
-     * Returns the specified queryString as a map.
-     * @param queryString
-     * @return
-     */
-    private static Map<String, String> getQueryAsMap(String queryString) {
-        queryString?.split('&').inject([:]) { map, token ->
-            token?.split('=').with { map[it[0]] = it[1] }
-            map
-        }
+        return matches
     }
 }

--- a/test/apps/memcached/test/functional/com/odobo/grails/plugin/springsecurity/rest/BearerTokenSpec.groovy
+++ b/test/apps/memcached/test/functional/com/odobo/grails/plugin/springsecurity/rest/BearerTokenSpec.groovy
@@ -129,6 +129,28 @@ class BearerTokenSpec extends AbstractRestSpec {
         response.status == 200
     }
 
+    @Issue("https://github.com/alvarosanchez/grails-spring-security-rest/issues/98")
+    void "accessing Anonymous without a token, responds  ok"() {
+        when:
+        def response = restBuilder.get("${baseUrl}/anonymous") {
+            contentType 'application/json;charset=UTF-8'
+        }
 
+        then:
+        response.status == 200
+    }
+
+//TODO: what should happen here?
+//    void "accessing Secured without a token, responds unauthorized"() {
+//        when:
+//        ErrorResponse response = restBuilder.post("${baseUrl}/secured") {
+//            contentType 'application/json;charset=UTF-8'
+//            body "{hi:777}"
+//        }
+//
+//        then:
+//        response.status == 401
+//        response.responseHeaders.getFirst('WWW-Authenticate') == 'Bearer '
+//    }
 
 }

--- a/test/unit/com/odobo/grails/plugin/springsecurity/rest/BearerTokenAuthenticationFailureHandlerSpec.groovy
+++ b/test/unit/com/odobo/grails/plugin/springsecurity/rest/BearerTokenAuthenticationFailureHandlerSpec.groovy
@@ -1,7 +1,9 @@
 package com.odobo.grails.plugin.springsecurity.rest
 
 import com.odobo.grails.plugin.springsecurity.rest.token.bearer.BearerTokenAuthenticationFailureHandler
+import com.odobo.grails.plugin.springsecurity.rest.token.bearer.BearerTokenReader
 import com.odobo.grails.plugin.springsecurity.rest.token.storage.TokenNotFoundException
+import org.codehaus.groovy.grails.web.mapping.LinkGenerator
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
@@ -10,8 +12,13 @@ import spock.lang.Specification
 class BearerTokenAuthenticationFailureHandlerSpec extends Specification {
 
     def handler = new BearerTokenAuthenticationFailureHandler()
+    def mockBearerTokenReader = Mock(BearerTokenReader)
 
-    def "it will send a 401 status and WWW-Authenticate header when no credentials were provided"() {
+    def setup() {
+        handler.tokenReader = mockBearerTokenReader
+    }
+
+    def "it will send a 400 status and WWW-Authenticate header when no credentials were provided and preconditions are not met"() {
         given:
         def request  = new MockHttpServletRequest()
         def response = new MockHttpServletResponse()
@@ -21,8 +28,8 @@ class BearerTokenAuthenticationFailureHandlerSpec extends Specification {
         handler.onAuthenticationFailure( request, response, exception )
 
         then:
-        response.status == 401
-        response.getHeader( 'WWW-Authenticate' ) == 'Bearer'
+        response.status == 400
+        response.getHeader( 'WWW-Authenticate' ) == 'Bearer error="invalid_request"'
     }
 
     def "it will send a 401 status and WWW-Authenticate header with an error param when credentials are invalid"() {
@@ -35,8 +42,26 @@ class BearerTokenAuthenticationFailureHandlerSpec extends Specification {
         handler.onAuthenticationFailure( request, response, exception )
 
         then:
+        1 * mockBearerTokenReader.findToken(request, response) >> "wrongToken"
+        1 * mockBearerTokenReader.matchesBearerSpecPreconditions(request, response) >> true
         response.status == 401
         response.getHeader( 'WWW-Authenticate' ) == 'Bearer error="invalid_token"'
+    }
+
+    def "it will send a 401 status and WWW-Authenticate header with an param when there is no token, but it matchesBearerSpecPreconditions"() {
+        given:
+        def request  = new MockHttpServletRequest()
+        def response = new MockHttpServletResponse()
+
+        when:
+        def exception = new TokenNotFoundException( 'Bad token :-(' )
+        handler.onAuthenticationFailure( request, response, exception )
+
+        then:
+        1 * mockBearerTokenReader.findToken(request, response) >> ""
+        1 * mockBearerTokenReader.matchesBearerSpecPreconditions(request, response) >> true
+        response.status == 401
+        response.getHeader( 'WWW-Authenticate' ) == 'Bearer '
     }
 
 }


### PR DESCRIPTION
Fixes issue [#98].
When an anonymous user without a token accesses an anonymous endpoint.
It was giving a 500 and throwing "java.lang.IllegalStateException: Cannot forward after response has been committed"
It now gives a 200.
- The main issue was in the BearerTokenReader as it was sendingError, 
- Moved all the error handling logic to the BearerTokenAuthenticationFailureHandler
  [#98]
