### PR TITLE
Ensure JWT Token signatures are verified. Fixes #172

### DIFF
--- a/src/groovy/com/odobo/grails/plugin/springsecurity/rest/token/storage/jwt/JwtTokenStorageService.groovy
+++ b/src/groovy/com/odobo/grails/plugin/springsecurity/rest/token/storage/jwt/JwtTokenStorageService.groovy
@@ -37,7 +37,9 @@ class JwtTokenStorageService implements TokenStorageService {
                 log.debug "Parsed an HMAC signed JWT"
 
                 SignedJWT signedJwt = jwt as SignedJWT
-                signedJwt.verify(new MACVerifier(jwtSecret))
+                if(!signedJwt.verify(new MACVerifier(jwtSecret))) {
+                    throw new JOSEException('Invalid signature')
+                }
             } else if (jwt instanceof EncryptedJWT) {
                 log.debug "Parsed an RSA encrypted JWT"
 

--- a/test/unit/com/odobo/grails/plugin/springsecurity/rest/token/storage/jwt/JwtTokenStorageServiceSpec.groovy
+++ b/test/unit/com/odobo/grails/plugin/springsecurity/rest/token/storage/jwt/JwtTokenStorageServiceSpec.groovy
@@ -1,0 +1,40 @@
+package com.odobo.grails.plugin.springsecurity.rest.token.storage.jwt
+
+import com.odobo.grails.plugin.springsecurity.rest.token.generation.jwt.SignedJwtTokenGenerator
+import com.odobo.grails.plugin.springsecurity.rest.token.storage.TokenNotFoundException
+import grails.test.mixin.TestFor
+import org.springframework.security.core.userdetails.User
+import spock.lang.Specification
+
+/**
+ * Created by @marcos-carceles on 03/03/15.
+ */
+@TestFor(JwtTokenStorageService)
+class JwtTokenStorageServiceSpec extends Specification {
+
+    JwtTokenStorageService service
+    SignedJwtTokenGenerator tokenGenerator
+
+    void setup() {
+        service = new JwtTokenStorageService(jwtSecret: 'fooo'*8)
+        tokenGenerator = new SignedJwtTokenGenerator(jwtSecret: 'fooo'*8, expiration: 60)
+    }
+
+    def "JWT Token signatures are verified"() {
+        given:
+        String token = tokenGenerator.generateToken(new User('testUser', 'testPassword', []))
+
+        when:
+        User user = service.loadUserByToken(token)
+
+        then:
+        user.username == 'testUser'
+
+        when:
+        service.loadUserByToken(token.replaceAll(/...$/,'bar'))
+
+        then:
+        thrown(TokenNotFoundException)
+
+    }
+}


### PR DESCRIPTION
SignedJWT seems to return `false` when the signature is incorrect, instead of throwing an exception.

Added a test around signature verification.