### PR TITLE
Add support for CAS authentication using OAuth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Contributors
 * [Andrew Wharton](https://github.com/andrew-wharton).
 * [Alonso Torres](https://github.com/Alotor).
 * [Bartek Gawel](https://github.com/bgawel).
+* [Bob Finch](https://github.com/rbfinch).
 * [Bobby Warner](https://github.com/bobbywarner).
 * [Burt Beckwith](https://github.com/burtbeckwith).
 * [Conall Laverty](https://github.com/conalllaverty).

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -18,6 +18,7 @@ grails.project.dependency.resolution = {
         compile 'com.google.guava:guava-io:r03'
         compile 'org.pac4j:pac4j-core:1.6.0'
         compile 'org.pac4j:pac4j-oauth:1.6.0'
+        compile 'org.pac4j:pac4j-cas:1.6.0'
         compile 'com.nimbusds:nimbus-jose-jwt:3.9'
 
         build("com.lowagie:itext:2.0.8") { excludes "bouncycastle:bcprov-jdk14:138", "org.bouncycastle:bcprov-jdk14:1.38" }

--- a/grails-app/controllers/grails/plugin/springsecurity/rest/RestOauthController.groovy
+++ b/grails-app/controllers/grails/plugin/springsecurity/rest/RestOauthController.groovy
@@ -22,10 +22,10 @@ import grails.plugin.springsecurity.rest.token.rendering.AccessTokenJsonRenderer
 import grails.plugin.springsecurity.rest.token.storage.TokenStorageService
 import org.apache.commons.codec.binary.Base64
 import org.codehaus.groovy.grails.commons.GrailsApplication
+import org.pac4j.core.client.BaseClient
 import org.pac4j.core.client.RedirectAction
 import org.pac4j.core.context.J2EContext
 import org.pac4j.core.context.WebContext
-import org.pac4j.oauth.client.BaseOAuthClient
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UsernameNotFoundException
@@ -51,7 +51,7 @@ class RestOauthController {
      * allows the frontend application to define the frontend callback URL on demand.
      */
     def authenticate(String provider, String callback) {
-        BaseOAuthClient client = restOauthService.getClient(provider)
+        BaseClient client = restOauthService.getClient(provider)
         WebContext context = new J2EContext(request, response)
 
         RedirectAction redirectAction = client.getRedirectAction(context, true, false)

--- a/src/docs/guide/oauth.gdoc
+++ b/src/docs/guide/oauth.gdoc
@@ -41,6 +41,9 @@ can use any OAuth 2.0 provider they support. This includes at the time of writin
 
 Note that OAuth 1.0a providers also work, like Twitter.
 
+The plugin also supports [CAS (Central Authentication Service)|https://www.apereo.org/projects/cas] using the OAuth
+authentication flow.  See [CAS Authentication|guide:oauth:cas] for details.
+
 To start the OAuth authentication flow, from your frontend application, generate a link to
 @<YOUR_GRAILS_APP>/oauth/authenticate/<provider>@. The user clicking on that link represents step 4 in the previous
 diagram.

--- a/src/docs/guide/oauth/cas.gdoc
+++ b/src/docs/guide/oauth/cas.gdoc
@@ -1,0 +1,26 @@
+Define the following block in your @Config.groovy@:
+
+{code}
+grails {
+    plugin {
+        springsecurity {
+
+            rest {
+
+                oauth {
+
+                    frontendCallbackUrl = { String tokenValue -> "http://my.frontend-app.com/welcome#token=${tokenValue}" }
+
+                    cas {
+
+                        client = org.pac4j.cas.client.CasClient
+                        casLoginUrl = "https://my.cas-server.com/cas/login"
+                    }
+                }
+            }
+        }
+    }
+}
+{code}
+
+Set @casLoginUrl@ to the login URL of your CAS server.

--- a/src/docs/guide/toc.yml
+++ b/src/docs/guide/toc.yml
@@ -21,5 +21,6 @@ oauth:
   google: Google
   facebook: Facebook
   twitter: Twitter
+  cas: CAS (Central Authentication Service)
 debugging: Debugging
 faq: Frequently Asked Questions


### PR DESCRIPTION
Implements #47.  A CAS provider can be configured in `Config.groovy` like this:

```
grails {
	plugin {
		springsecurity {
			rest {
				oauth {
					cas {
						client = org.pac4j.cas.client.CasClient
						casLoginUrl = "https://mycasserver.example.com/cas/login"
					}
				}
			}
		}
	}
}
```

Currently, the Pac4J client properties that can be configured are hardwired in `RestOauthService`.  Perhaps, it would be better to specify a closure in the oauth provider config that would allow any client specific property to be set.