### PR TITLE
fixes #237

### DIFF
--- a/SpringSecurityRestGrailsPlugin.groovy
+++ b/SpringSecurityRestGrailsPlugin.groovy
@@ -5,6 +5,7 @@ import grails.plugin.springsecurity.rest.authentication.DefaultRestAuthenticatio
 import grails.plugin.springsecurity.rest.authentication.NullRestAuthenticationEventPublisher
 import grails.plugin.springsecurity.rest.credentials.DefaultJsonPayloadCredentialsExtractor
 import grails.plugin.springsecurity.rest.credentials.RequestParamsCredentialsExtractor
+import grails.plugin.springsecurity.rest.error.DefaultCallbackErrorHandler
 import grails.plugin.springsecurity.rest.oauth.DefaultOauthUserDetailsService
 import grails.plugin.springsecurity.rest.token.bearer.BearerTokenAccessDeniedHandler
 import grails.plugin.springsecurity.rest.token.bearer.BearerTokenAuthenticationEntryPoint
@@ -176,6 +177,8 @@ class SpringSecurityRestGrailsPlugin {
 
         /* tokenGenerator */
         tokenGenerator(SecureRandomTokenGenerator)
+
+        callbackErrorHandler(DefaultCallbackErrorHandler)
 
         /* tokenStorageService */
         if (conf.rest.token.storage.useMemcached) {

--- a/grails-app/controllers/grails/plugin/springsecurity/rest/RestOauthController.groovy
+++ b/grails-app/controllers/grails/plugin/springsecurity/rest/RestOauthController.groovy
@@ -109,13 +109,8 @@ class RestOauthController {
     }
 
     private String getCallbackUrl(baseUrl, String queryStringSuffix) {
-        if (session[CALLBACK_ATTR]) {
-            session[CALLBACK_ATTR] = null
-            baseUrl + queryStringSuffix
-
-        } else {
-            baseUrl.call(queryStringSuffix)
-        }
+        session[CALLBACK_ATTR] = null
+        baseUrl instanceof Closure ? baseUrl(queryStringSuffix) : baseUrl + queryStringSuffix
     }
 
     /**

--- a/grails-app/controllers/grails/plugin/springsecurity/rest/RestOauthController.groovy
+++ b/grails-app/controllers/grails/plugin/springsecurity/rest/RestOauthController.groovy
@@ -17,6 +17,7 @@
 package grails.plugin.springsecurity.rest
 
 import grails.plugin.springsecurity.annotation.Secured
+import grails.plugin.springsecurity.rest.error.CallbackErrorHandler
 import grails.plugin.springsecurity.rest.token.AccessToken
 import grails.plugin.springsecurity.rest.token.rendering.AccessTokenJsonRenderer
 import grails.plugin.springsecurity.rest.token.storage.TokenStorageService
@@ -39,6 +40,7 @@ class RestOauthController {
 
     final String CALLBACK_ATTR = "spring-security-rest-callback"
 
+    CallbackErrorHandler callbackErrorHandler
     RestOauthService restOauthService
     GrailsApplication grailsApplication
 
@@ -89,34 +91,31 @@ class RestOauthController {
 
         try {
             String tokenValue = restOauthService.storeAuthentication(provider, context)
-
-            if (session[CALLBACK_ATTR]) {
-                frontendCallbackUrl += tokenValue
-                session[CALLBACK_ATTR] = null
-            } else {
-                frontendCallbackUrl = frontendCallbackUrl.call(tokenValue)
-            }
+            frontendCallbackUrl = getCallbackUrl(frontendCallbackUrl, tokenValue)
 
         } catch (Exception e) {
-            String errorParams
+            def errorParams = new StringBuilder()
 
-            if (e instanceof UsernameNotFoundException) {
-                errorParams = "&error=403&message=${e.message?.encodeAsURL()?:''}"
-            } else {
-                errorParams = "&error=${e.cause?.code?:500}&message=${e.message?.encodeAsURL()?:''}"
+            Map params = callbackErrorHandler.convert(e)
+            params.each { key, value ->
+                errorParams << "&${key}=${value.encodeAsURL()}"
             }
 
-            if (session[CALLBACK_ATTR]) {
-                frontendCallbackUrl += errorParams
-                session[CALLBACK_ATTR] = null
-            } else {
-                frontendCallbackUrl = frontendCallbackUrl.call(errorParams)
-            }
-
+            frontendCallbackUrl = getCallbackUrl(frontendCallbackUrl, errorParams.toString())
         }
 
         log.debug "Redirecting to ${frontendCallbackUrl}"
         redirect url: frontendCallbackUrl
+    }
+
+    private String getCallbackUrl(baseUrl, String queryStringSuffix) {
+        if (session[CALLBACK_ATTR]) {
+            session[CALLBACK_ATTR] = null
+            baseUrl + queryStringSuffix
+
+        } else {
+            baseUrl.call(queryStringSuffix)
+        }
     }
 
     /**

--- a/grails-app/controllers/grails/plugin/springsecurity/rest/RestOauthController.groovy
+++ b/grails-app/controllers/grails/plugin/springsecurity/rest/RestOauthController.groovy
@@ -91,13 +91,7 @@ class RestOauthController {
 
         try {
             String tokenValue = restOauthService.storeAuthentication(provider, context)
-
-            if (session[CALLBACK_ATTR]) {
-                frontendCallbackUrl += tokenValue
-                session[CALLBACK_ATTR] = null
-            } else {
-                frontendCallbackUrl = frontendCallbackUrl.call(tokenValue)
-            }
+            frontendCallbackUrl = getCallbackUrl(frontendCallbackUrl, tokenValue)
 
         } catch (Exception e) {
             def errorParams = new StringBuilder()
@@ -107,16 +101,21 @@ class RestOauthController {
                 errorParams << "&${key}=${value.encodeAsURL()}"
             }
 
-            if (session[CALLBACK_ATTR]) {
-                frontendCallbackUrl += errorParams.toString()
-                session[CALLBACK_ATTR] = null
-            } else {
-                frontendCallbackUrl = frontendCallbackUrl.call(errorParams.toString())
-            }
+            frontendCallbackUrl = getCallbackUrl(frontendCallbackUrl, errorParams.toString())
         }
 
         log.debug "Redirecting to ${frontendCallbackUrl}"
         redirect url: frontendCallbackUrl
+    }
+
+    private String getCallbackUrl(baseUrl, String queryStringSuffix) {
+        if (session[CALLBACK_ATTR]) {
+            session[CALLBACK_ATTR] = null
+            baseUrl + queryStringSuffix
+
+        } else {
+            baseUrl.call(queryStringSuffix)
+        }
     }
 
     /**

--- a/src/docs/guide/oauth.gdoc
+++ b/src/docs/guide/oauth.gdoc
@@ -49,20 +49,28 @@ To start the OAuth authentication flow, from your frontend application, generate
 diagram.
 
 Note that you can define the frontend callback URL in @Config.groovy@ under
-@grails.plugin.springsecurity.rest.oauth.frontendCallbackUrl@. You need to define a closure that will be called with
-the token value as parameter:
+@grails.plugin.springsecurity.rest.oauth.frontendCallbackUrl@.
 
 {code}
-grails.plugin.springsecurity.rest.oauth.frontendCallbackUrl = { String tokenValue -> "http://my.frontend-app.com/welcome#token=${tokenValue}" }
+grails.plugin.springsecurity.rest.oauth.frontendCallbackUrl = "http://my.frontend-app.com/welcome#token="
 {code}
+
+The token will be concatenated to the end of the URL.
+
+{note}
+For backwards compatibility with versions 1.5.2 and earlier, the callback URL can also be defined as a closure that will
+be called with the token value as a parameter:
+
+    {code}
+    grails.plugin.springsecurity.rest.oauth.frontendCallbackUrl = { String tokenValue -> "http://my.frontend-app.com/welcome#token=${tokenValue}" }
+    {code}
+{note}
 
 You can also define the URL as a @callback@ parameter in the original link, eg:
 
 {code}
 http://your-grails-api.com/oauth/authenticate/google?callback=http://your-frontend-app.com/auth-success.html?token=
 {code}
-
-In this case, the token will be *concatenated* to the end of the URL.
 
 Upon successful OAuth authorisation (after step 6.1 in the above diagram), an
 [OauthUser|http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/gapi/grails/plugin/springsecurity/rest/oauth/OauthUser.html]
@@ -127,12 +135,38 @@ OauthUser loadUserByUserProfile(OAuth20Profile userProfile, Collection<GrantedAu
 }
 {code}
 
-In case of any OAuth authentication failure, the plugin will redirect back to the frontend application anyway, so it
-has a chance to render a proper error message and/or offer the user the option to try again. In that case, the token
-parameter will be empty, and both @error@ and @message@ params will be appended:
+h3. Error Handling
+
+In case of any OAuth authentication failure, the plugin will redirect back to the frontend application so it
+can render an error message and/or offer the user the option to try again. When an error occurs, the token
+parameter will be empty, and error parameters will be appended to the callback URL e.g.
 
 {code}
-http://your-frontend-app.com/auth-success.html?token=&error=403&message=User+with+email+jimmy%40gmail.com+now+allowed.+Only+%40example.com+accounts+are+allowed
+http://your-frontend-app.com/auth-success.html?token=&error=403&message=User+with+email+jimmy%40gmail.com+now+allowed&error_description=User+with+email+jimmy%40gmail.com+not+allowed&error_code=UsernameNotFoundException
 {code}
 
-Below are some examples on how to configure it for Google, Facebook and Twitter.
+A description of each error parameter is given below
+
+* @error@ - a code describing the error. This parameter is required by [RFC 6749|https://tools.ietf.org/html/rfc6749]
+* @error_description@ - a human readable message describing the error. This parameter is optional according to [RFC 6749|https://tools.ietf.org/html/rfc6749]
+* @message@ - the value of this parameter will be identical to @error_description@, it is provided only for backwards compatability with versions 1.5.2 and earlier which omitted @error_description@
+* @error_code@ - the value of this parameter will be simple name of the exception that caused the error
+
+The error handling described above is implemented by a Spring bean named @callbackErrorHandler@. This behaviour can be customised
+by providing a replacement bean of the same name that implements this interface
+
+{code}
+interface CallbackErrorHandler {
+
+    /**
+     * Converts an error that occurs during the callback to a parameter map that will be returned to the frontend
+     * @param cause
+     * @return
+     */
+    Map convert(Exception cause)
+}
+{code}
+
+It is strongly recommended (but not enforced by the plugin) that you include in the returned @Map@ any parameters required by [RFC 6749|https://tools.ietf.org/html/rfc6749]
+
+The following sections provide examples of how to configure the plugin for usage with some popular OAuth providers: Google, Facebook and Twitter.

--- a/src/groovy/grails/plugin/springsecurity/rest/error/CallbackErrorHandler.groovy
+++ b/src/groovy/grails/plugin/springsecurity/rest/error/CallbackErrorHandler.groovy
@@ -1,5 +1,20 @@
+/*
+ * Copyright 2013-2015 Alvaro Sanchez-Mariscal <alvaro.sanchezmariscal@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package grails.plugin.springsecurity.rest.error
-
 
 interface CallbackErrorHandler {
 
@@ -7,6 +22,8 @@ interface CallbackErrorHandler {
      * Converts an error that occurs during the callback to a parameter map that will be returned to the frontend
      * @param cause
      * @return
+     *
+     * @author Dónal Murtagh
      */
     Map convert(Exception cause)
 }

--- a/src/groovy/grails/plugin/springsecurity/rest/error/CallbackErrorHandler.groovy
+++ b/src/groovy/grails/plugin/springsecurity/rest/error/CallbackErrorHandler.groovy
@@ -5,8 +5,8 @@ interface CallbackErrorHandler {
 
     /**
      * Converts an error that occurs during the callback to a parameter map that will be returned to the frontend
-     * @param e
+     * @param cause
      * @return
      */
-    Map convert(Exception e)
+    Map convert(Exception cause)
 }

--- a/src/groovy/grails/plugin/springsecurity/rest/error/CallbackErrorHandler.groovy
+++ b/src/groovy/grails/plugin/springsecurity/rest/error/CallbackErrorHandler.groovy
@@ -1,0 +1,12 @@
+package grails.plugin.springsecurity.rest.error
+
+
+interface CallbackErrorHandler {
+
+    /**
+     * Converts an error that occurs during the callback to a parameter map that will be returned to the frontend
+     * @param e
+     * @return
+     */
+    Map convert(Exception e)
+}

--- a/src/groovy/grails/plugin/springsecurity/rest/error/DefaultCallbackErrorHandler.groovy
+++ b/src/groovy/grails/plugin/springsecurity/rest/error/DefaultCallbackErrorHandler.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2015 Alvaro Sanchez-Mariscal <alvaro.sanchezmariscal@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package grails.plugin.springsecurity.rest.error
 
 import org.springframework.security.core.userdetails.UsernameNotFoundException
@@ -8,6 +24,8 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 /**
  * Error handler that's backwardly compatible with the behaviour that was embedded within the callback action of
  * RestOauthController up to and including version 1.5.2
+ *
+ * @author Dónal Murtagh
  */
 class DefaultCallbackErrorHandler implements CallbackErrorHandler {
 

--- a/src/groovy/grails/plugin/springsecurity/rest/error/DefaultCallbackErrorHandler.groovy
+++ b/src/groovy/grails/plugin/springsecurity/rest/error/DefaultCallbackErrorHandler.groovy
@@ -26,7 +26,7 @@ class DefaultCallbackErrorHandler implements CallbackErrorHandler {
         // Add the error message under the keys 'error_description' and 'message' - the former for compatibility with
         // the RFC and the latter for backwards compatibility with plugin versions <= 1.5.2
         params.error_description = params.message = e.message ?: ''
-        params.error_code= e.cause ? e.cause.class.simpleName : e.class.simpleName
+        params.error_code = e.cause ? e.cause.class.simpleName : e.class.simpleName
         params
     }
 }

--- a/src/groovy/grails/plugin/springsecurity/rest/error/DefaultCallbackErrorHandler.groovy
+++ b/src/groovy/grails/plugin/springsecurity/rest/error/DefaultCallbackErrorHandler.groovy
@@ -1,0 +1,32 @@
+package grails.plugin.springsecurity.rest.error
+
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+
+import static org.springframework.http.HttpStatus.FORBIDDEN
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
+
+/**
+ * Error handler that's backwardly compatible with the behaviour that was embedded within the callback action of
+ * RestOauthController up to and including version 1.5.2
+ */
+class DefaultCallbackErrorHandler implements CallbackErrorHandler {
+
+    @Override
+    Map convert(Exception e) {
+
+        Map params = [:]
+
+        if (e instanceof UsernameNotFoundException) {
+            params.error = FORBIDDEN.value()
+
+        } else {
+            params.error = e.cause?.hasProperty('code') ? e.cause.code : INTERNAL_SERVER_ERROR.value()
+        }
+
+        // Add the error message under the keys 'error_description' and 'message' - the former for compatibility with
+        // the RFC and the latter for backwards compatibility with plugin versions <= 1.5.2
+        params.error_description = params.message = e.message ?: ''
+        params.error_code= e.cause ? e.cause.class.simpleName : e.class.simpleName
+        params
+    }
+}

--- a/test/integration/grails/plugin/springsecurity/rest/RestOauthControllerSpec.groovy
+++ b/test/integration/grails/plugin/springsecurity/rest/RestOauthControllerSpec.groovy
@@ -1,0 +1,77 @@
+package grails.plugin.springsecurity.rest
+
+import grails.plugin.springsecurity.rest.error.CallbackErrorHandler
+import grails.plugin.springsecurity.rest.token.generation.TokenGenerator
+import grails.plugin.springsecurity.rest.token.rendering.AccessTokenJsonRenderer
+import grails.plugin.springsecurity.rest.token.storage.TokenStorageService
+import grails.test.spock.IntegrationSpec
+import groovy.util.logging.Log4j
+import org.codehaus.groovy.grails.commons.GrailsApplication
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+
+@Log4j
+class RestOauthControllerSpec extends IntegrationSpec {
+
+    private RestOauthController controller
+
+    CallbackErrorHandler callbackErrorHandler
+    RestOauthService restOauthService
+    GrailsApplication grailsApplication
+
+    TokenStorageService tokenStorageService
+    TokenGenerator tokenGenerator
+    AccessTokenJsonRenderer accessTokenJsonRenderer
+
+    private callbackUrlConfig = "http://config.com/welcome#token="
+
+    def setup() {
+
+        controller = new RestOauthController(
+                callbackErrorHandler: callbackErrorHandler,
+                restOauthService: restOauthService,
+                grailsApplication: grailsApplication,
+                tokenStorageService: tokenStorageService,
+                tokenGenerator: tokenGenerator,
+                accessTokenJsonRenderer: accessTokenJsonRenderer
+        )
+
+        grailsApplication.config.grails.plugin.springsecurity.rest.oauth.frontendCallbackUrl = { String tokenValue ->
+            callbackUrlConfig + tokenValue
+        }
+    }
+
+    private Exception stubService(Exception caughtException) {
+        def stubRestOauthService = Stub(RestOauthService)
+        stubRestOauthService.storeAuthentication(*_) >> { throw caughtException }
+        controller.restOauthService = stubRestOauthService
+        caughtException
+    }
+
+    def 'UsernameNotFoundException caught within callback action with frontend URL in Config.groovy'() {
+
+        def caughtException = stubService(new UsernameNotFoundException('message'))
+
+        when:
+        controller.params.provider = "google"
+        controller.callback()
+
+        then:
+        def message = caughtException.message
+        controller.response.redirectedUrl == "${callbackUrlConfig}&error=403&message=${message}&error_description=${message}&error_code=${caughtException.class.simpleName}"
+    }
+
+//    def 'UsernameNotFoundException caught within callback action with frontend URL in session'() {
+//
+//        def callbackUrlSession = { String tokenValue -> "http://session.com/welcome#token=${tokenValue}" }
+//        controller.session[controller.CALLBACK_ATTR] = callbackUrlSession
+//        def caughtException = stubService(new UsernameNotFoundException('message'))
+//
+//        when:
+//        controller.params.provider = "google"
+//        controller.callback()
+//
+//        then:
+//        def message = caughtException.message
+//        controller.response.redirectedUrl == "${callbackUrlSession}&error=403&message=${message}&error_description=${message}&error_code=${caughtException.class.simpleName}"
+//    }
+}

--- a/test/integration/grails/plugin/springsecurity/rest/RestOauthControllerSpec.groovy
+++ b/test/integration/grails/plugin/springsecurity/rest/RestOauthControllerSpec.groovy
@@ -1,6 +1,7 @@
 package grails.plugin.springsecurity.rest
 
 import grails.plugin.springsecurity.rest.error.CallbackErrorHandler
+import grails.plugin.springsecurity.rest.error.DefaultCallbackErrorHandler
 import grails.plugin.springsecurity.rest.token.generation.TokenGenerator
 import grails.plugin.springsecurity.rest.token.rendering.AccessTokenJsonRenderer
 import grails.plugin.springsecurity.rest.token.storage.TokenStorageService
@@ -19,13 +20,7 @@ class RestOauthControllerSpec extends IntegrationSpec {
 
     private RestOauthController controller
 
-    CallbackErrorHandler callbackErrorHandler
-    RestOauthService restOauthService
     GrailsApplication grailsApplication
-
-    TokenStorageService tokenStorageService
-    TokenGenerator tokenGenerator
-    AccessTokenJsonRenderer accessTokenJsonRenderer
 
     /**
      * The frontend callback URL stored in config.groovy
@@ -37,14 +32,7 @@ class RestOauthControllerSpec extends IntegrationSpec {
             frontendCallbackBaseUrl + tokenValue
         }
 
-        controller = new RestOauthController(
-                callbackErrorHandler: callbackErrorHandler,
-                restOauthService: restOauthService,
-                grailsApplication: grailsApplication,
-                tokenStorageService: tokenStorageService,
-                tokenGenerator: tokenGenerator,
-                accessTokenJsonRenderer: accessTokenJsonRenderer
-        )
+        controller = new RestOauthController(callbackErrorHandler: new DefaultCallbackErrorHandler())
     }
 
     private Exception stubService(Exception caughtException) {

--- a/test/unit/grails/plugin/springsecurity/rest/RestOauthControllerSpec.groovy
+++ b/test/unit/grails/plugin/springsecurity/rest/RestOauthControllerSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2015 Alvaro Sanchez-Mariscal <alvaro.sanchezmariscal@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package grails.plugin.springsecurity.rest
 
 import grails.plugin.springsecurity.rest.error.DefaultCallbackErrorHandler

--- a/test/unit/grails/plugin/springsecurity/rest/RestOauthControllerSpec.groovy
+++ b/test/unit/grails/plugin/springsecurity/rest/RestOauthControllerSpec.groovy
@@ -23,6 +23,8 @@ class RestOauthControllerSpec extends Specification {
         grailsApplication.config.grails.plugin.springsecurity.rest.oauth.frontendCallbackUrl = { String tokenValue ->
             frontendCallbackBaseUrl + tokenValue
         }
+
+        params.provider = "google"
     }
 
     private Exception injectDependencies(Exception caughtException) {
@@ -41,7 +43,6 @@ class RestOauthControllerSpec extends Specification {
     def 'UsernameNotFoundException caught within callback action with frontend URL in Config.groovy'() {
 
         def caughtException = injectDependencies(new UsernameNotFoundException('message'))
-        params.provider = "google"
 
         when:
         controller.callback()
@@ -56,7 +57,6 @@ class RestOauthControllerSpec extends Specification {
         def caughtException = injectDependencies(new UsernameNotFoundException('message'))
         def frontendCallbackBaseUrlSession = "http://session.com/welcome#token="
         request.session[controller.CALLBACK_ATTR] = frontendCallbackBaseUrlSession
-        params.provider = "google"
 
         when:
         controller.callback()
@@ -68,8 +68,7 @@ class RestOauthControllerSpec extends Specification {
 
     def 'Non-UsernameNotFoundException with cause that has code caught within callback action'() {
 
-        ExceptionWithCodedCause caughtException = injectDependencies(new ExceptionWithCodedCause('message'))
-        params.provider = "google"
+        def caughtException = injectDependencies(new ExceptionWithCodedCause('message'))
 
         when:
         controller.callback()
@@ -82,7 +81,6 @@ class RestOauthControllerSpec extends Specification {
     def 'Non-UsernameNotFoundException without cause caught within callback action'() {
 
         def caughtException = injectDependencies(new Exception('message'))
-        params.provider = "google"
 
         when:
         controller.callback()

--- a/test/unit/grails/plugin/springsecurity/rest/RestOauthControllerSpec.groovy
+++ b/test/unit/grails/plugin/springsecurity/rest/RestOauthControllerSpec.groovy
@@ -40,9 +40,22 @@ class RestOauthControllerSpec extends Specification {
         "${baseUrl}&error=${expectedErrorValue}&message=${message}&error_description=${message}&error_code=${exception.class.simpleName}"
     }
 
-    def 'UsernameNotFoundException caught within callback action with frontend URL in Config.groovy'() {
+    def 'UsernameNotFoundException caught within callback action with frontend closure URL in Config.groovy'() {
 
         def caughtException = injectDependencies(new UsernameNotFoundException('message'))
+
+        when:
+        controller.callback()
+
+        then:
+        String expectedUrl = getExpectedUrl(caughtException, FORBIDDEN.value())
+        response.redirectedUrl == expectedUrl
+    }
+
+    def 'UsernameNotFoundException caught within callback action with frontend string URL in Config.groovy'() {
+
+        def caughtException = injectDependencies(new UsernameNotFoundException('message'))
+        grailsApplication.config.grails.plugin.springsecurity.rest.oauth.frontendCallbackUrl = frontendCallbackBaseUrl
 
         when:
         controller.callback()

--- a/test/unit/grails/plugin/springsecurity/rest/RestOauthControllerSpec.groovy
+++ b/test/unit/grails/plugin/springsecurity/rest/RestOauthControllerSpec.groovy
@@ -7,6 +7,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException
 import spock.lang.Issue
 import spock.lang.Specification
 
+import static org.springframework.http.HttpStatus.FORBIDDEN
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 
 @Issue("https://github.com/alvarosanchez/grails-spring-security-rest/issues/237")
@@ -46,7 +47,7 @@ class RestOauthControllerSpec extends Specification {
         controller.callback()
 
         then:
-        String expectedUrl = getExpectedUrl(caughtException, 403)
+        String expectedUrl = getExpectedUrl(caughtException, FORBIDDEN.value())
         response.redirectedUrl == expectedUrl
     }
 
@@ -61,7 +62,7 @@ class RestOauthControllerSpec extends Specification {
         controller.callback()
 
         then:
-        String expectedUrl = getExpectedUrl(caughtException, 403, frontendCallbackBaseUrlSession)
+        String expectedUrl = getExpectedUrl(caughtException, FORBIDDEN.value(), frontendCallbackBaseUrlSession)
         response.redirectedUrl == expectedUrl
     }
 


### PR DESCRIPTION
I made the changes discussed in #237, added specs and updated the docs.

You'd suggested replacing the `message` parameter with `error_description` to conform to the RFC, but I ultimately decided to include both of them in order to maintain backwards compatibility with earlier plugin versions.

I tidied up the code in `RestOauthController.callback` to make it a bit DRYer/simpler and also made one other change we didn't discuss:

You can now specify the frontend callback URL in `Config.groovy` in the same format as you specify it via a URL parameter, i.e.

    grails.plugin.springsecurity.rest.oauth.frontendCallbackUrl = "http://my.frontend-app.com/welcome#token="

The closure syntax is still supported for backwards compatibility, but I felt this was a small improvement worth making.

### Aside

I noticed when reading the RFC that the value of the `error` parameter is supposed to be one of the values from this list

 - invalid_request
 - unauthorized_client
 - access_denied
 - unsupported_response_type
 - invalid_scope
 - server_error
 - temporarily_unavailable

The plugin does not adhere to this. Obviously this can't be changed without potentially breaking existing clients. Arguably, this specification doesn't strictly apply here, because the RFC is describing how errors should be passed from the OAuth provider to the client, but in this case we're passing errors to the frontend app rather than the OAuth client (which is the Grails app that installs this plugin).