### PR TITLE
Allowing to use any kind of implemented TokenReader with bearer token

### DIFF
--- a/src/groovy/grails/plugin/springsecurity/rest/token/bearer/BearerTokenAuthenticationEntryPoint.groovy
+++ b/src/groovy/grails/plugin/springsecurity/rest/token/bearer/BearerTokenAuthenticationEntryPoint.groovy
@@ -17,6 +17,7 @@
 package grails.plugin.springsecurity.rest.token.bearer
 
 import grails.plugin.springsecurity.rest.token.AccessToken
+import grails.plugin.springsecurity.rest.token.reader.TokenReader
 import groovy.util.logging.Slf4j
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.web.AuthenticationEntryPoint
@@ -31,7 +32,7 @@ import javax.servlet.http.HttpServletResponse
 @Slf4j
 class BearerTokenAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-    BearerTokenReader tokenReader
+    TokenReader tokenReader
 
     @Override
     void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)

--- a/src/groovy/grails/plugin/springsecurity/rest/token/bearer/BearerTokenAuthenticationFailureHandler.groovy
+++ b/src/groovy/grails/plugin/springsecurity/rest/token/bearer/BearerTokenAuthenticationFailureHandler.groovy
@@ -17,6 +17,7 @@
 package grails.plugin.springsecurity.rest.token.bearer
 
 import grails.plugin.springsecurity.rest.token.AccessToken
+import grails.plugin.springsecurity.rest.token.reader.TokenReader
 import groovy.util.logging.Slf4j
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.web.authentication.AuthenticationFailureHandler
@@ -31,7 +32,7 @@ import javax.servlet.http.HttpServletResponse
 @Slf4j
 class BearerTokenAuthenticationFailureHandler implements AuthenticationFailureHandler {
 
-    BearerTokenReader tokenReader
+    TokenReader tokenReader
 
     /**
      * Sends the proper response code and headers, as defined by RFC6750.


### PR DESCRIPTION
Allowing to use any kind of implemented TokenReader with bearer token type: BearerTokenReader -> TokenReader.
When other tokenReader bean is provided, the TokenReader instanciation fails.