### PR TITLE
Rsa signature support

### DIFF
--- a/spring-security-rest/build.gradle
+++ b/spring-security-rest/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     }
     compile 'commons-codec:commons-codec:1.10'
     compile "org.grails.plugins:spring-security-core:3.1.1"
+    compile "org.bouncycastle:bcprov-jdk15on:1.51"
 
     testCompile "org.gperfutils:gbench:0.4.3-groovy-2.4"
 

--- a/spring-security-rest/grails-app/services/grails/plugin/springsecurity/rest/JwtService.groovy
+++ b/spring-security-rest/grails-app/services/grails/plugin/springsecurity/rest/JwtService.groovy
@@ -17,8 +17,11 @@
 package grails.plugin.springsecurity.rest
 
 import com.nimbusds.jose.JOSEException
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSVerifier
 import com.nimbusds.jose.crypto.MACVerifier
 import com.nimbusds.jose.crypto.RSADecrypter
+import com.nimbusds.jose.crypto.RSASSAVerifier
 import com.nimbusds.jwt.EncryptedJWT
 import com.nimbusds.jwt.JWT
 import com.nimbusds.jwt.JWTParser
@@ -56,7 +59,10 @@ class JwtService {
             log.debug "Parsed an HMAC signed JWT"
 
             SignedJWT signedJwt = jwt as SignedJWT
-            if(!signedJwt.verify(new MACVerifier(jwtSecret))) {
+            JWSVerifier verifier = jwt.header.algorithm.equals(JWSAlgorithm.RS256) ?
+                    new RSASSAVerifier(keyProvider.publicKey) : new MACVerifier(jwtSecret)
+
+            if(!signedJwt.verify(new MACVerifier(verifier))) {
                 throw new JOSEException('Invalid signature')
             }
         } else if (jwt instanceof EncryptedJWT) {

--- a/spring-security-rest/grails-app/services/grails/plugin/springsecurity/rest/JwtService.groovy
+++ b/spring-security-rest/grails-app/services/grails/plugin/springsecurity/rest/JwtService.groovy
@@ -56,14 +56,22 @@ class JwtService {
         JWT jwt = JWTParser.parse(tokenValue)
 
         if (jwt instanceof  SignedJWT) {
-            log.debug "Parsed an HMAC signed JWT"
+            log.debug "Parsed a signed JWT"
 
             SignedJWT signedJwt = jwt as SignedJWT
-            JWSVerifier verifier = jwt.header.algorithm.equals(JWSAlgorithm.RS256) ?
-                    new RSASSAVerifier(keyProvider.publicKey) : new MACVerifier(jwtSecret)
-
-            if(!signedJwt.verify(new MACVerifier(verifier))) {
+            JWSVerifier verifier = null
+            if (jwt.header.algorithm.equals(JWSAlgorithm.RS256)) {
+                log.debug "RSA key"
+                verifier = new RSASSAVerifier(keyProvider.publicKey)
+            } else {
+                log.debug "HMAC key"
+                verifier = new MACVerifier(jwtSecret)
+            }
+            log.debug "verifier created"
+            if(!signedJwt.verify(verifier)) {
                 throw new JOSEException('Invalid signature')
+            } else {
+                log.debug "valid token"
             }
         } else if (jwt instanceof EncryptedJWT) {
             log.debug "Parsed an RSA encrypted JWT"

--- a/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGrailsPlugin.groovy
+++ b/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGrailsPlugin.groovy
@@ -40,6 +40,7 @@ import grails.plugin.springsecurity.rest.token.generation.jwt.EncryptedJwtTokenG
 import grails.plugin.springsecurity.rest.token.generation.jwt.FileRSAKeyProvider
 import grails.plugin.springsecurity.rest.token.generation.jwt.IssuerClaimProvider
 import grails.plugin.springsecurity.rest.token.generation.jwt.SignedJwtTokenGenerator
+import grails.plugin.springsecurity.rest.token.generation.jwt.StringRSAKeyProvider
 import grails.plugin.springsecurity.rest.token.reader.HttpHeaderTokenReader
 import grails.plugin.springsecurity.rest.token.rendering.DefaultAccessTokenJsonRenderer
 import grails.plugin.springsecurity.rest.token.storage.jwt.JwtTokenStorageService
@@ -226,25 +227,33 @@ class SpringSecurityRestGrailsPlugin extends Plugin {
                 encryptionMethod = EncryptionMethod.parse(conf.rest.token.generation.jwt.encryptionMethod)
             }
 
-            if (conf.rest.token.storage.jwt.privateKeyPath instanceof CharSequence &&
-                    conf.rest.token.storage.jwt.publicKeyPath instanceof CharSequence) {
-                keyProvider(FileRSAKeyProvider) {
-                    privateKeyPath = conf.rest.token.storage.jwt.privateKeyPath
-                    publicKeyPath = conf.rest.token.storage.jwt.publicKeyPath
-                }
-            } else {
-                keyProvider(DefaultRSAKeyProvider)
-            }
-
         } else if (conf.rest.token.storage.jwt.useSignedJwt) {
             checkJwtSecret(jwtSecretValue)
 
             tokenGenerator(SignedJwtTokenGenerator) {
                 jwtTokenStorageService = ref('tokenStorageService')
+                keyProvider = ref('keyProvider')
                 jwtSecret = jwtSecretValue
                 defaultExpiration = conf.rest.token.storage.jwt.expiration
                 jwsAlgorithm = JWSAlgorithm.parse(conf.rest.token.generation.jwt.algorithm)
             }
+        }
+
+
+        if (conf.rest.token.storage.jwt.privateKeyPath instanceof CharSequence &&
+                conf.rest.token.storage.jwt.publicKeyPath instanceof CharSequence) {
+            keyProvider(FileRSAKeyProvider) {
+                privateKeyPath = conf.rest.token.storage.jwt.privateKeyPath
+                publicKeyPath = conf.rest.token.storage.jwt.publicKeyPath
+            }
+        } else if (conf.rest.token.storage.jwt.privateKey instanceof CharSequence ||
+                conf.rest.token.storage.jwt.publicKey instanceof CharSequence) {
+            keyProvider(StringRSAKeyProvider) {
+                privateKeyStr = conf.rest.token.storage.jwt.privateKey
+                publicKeyStr = conf.rest.token.storage.jwt.publicKey
+            }
+        } else {
+            keyProvider(DefaultRSAKeyProvider)
         }
 
         /* restAuthenticationProvider */

--- a/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGrailsPlugin.groovy
+++ b/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGrailsPlugin.groovy
@@ -248,7 +248,7 @@ class SpringSecurityRestGrailsPlugin extends Plugin {
 
         } else if (conf.rest.token.storage.jwt.useSignedJwt) {
             Map<String, RSAKeyProvider> providersMap
-            List issuerKeys = conf.rest.token.storage.jwt.keys
+            def issuerKeys = conf.rest.token.storage.jwt.keys
             if (issuerKeys) {
                 log.debug "parsing issuers keys"
                 providersMap = issuerKeys.inject([:]) { memo, item ->

--- a/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/token/bearer/BearerTokenReader.groovy
+++ b/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/token/bearer/BearerTokenReader.groovy
@@ -42,7 +42,8 @@ class BearerTokenReader implements TokenReader {
         String tokenValue = null
         String header = request.getHeader('Authorization')
 
-        if (header?.startsWith('Bearer') && header.length()>=8) {
+        //temporary fix, spring-security-oauth2 proxy forward request with lowercase bearer code
+        if (header?.toLowerCase().startsWith('bearer') && header.length()>=8) {
             log.debug "Found bearer token in Authorization header"
             tokenValue = header.substring(7)
         } else if (isFormEncoded(request) && !request.get) {

--- a/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/token/bearer/BearerTokenReader.groovy
+++ b/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/token/bearer/BearerTokenReader.groovy
@@ -43,7 +43,7 @@ class BearerTokenReader implements TokenReader {
         String header = request.getHeader('Authorization')
 
         //temporary fix, spring-security-oauth2 proxy forward request with lowercase bearer code
-        if (header?.toLowerCase().startsWith('bearer') && header.length()>=8) {
+        if (header?.toLowerCase()?.startsWith('bearer') && header.length()>=8) {
             log.debug "Found bearer token in Authorization header"
             tokenValue = header.substring(7)
         } else if (isFormEncoded(request) && !request.get) {

--- a/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/token/generation/jwt/SignedJwtTokenGenerator.groovy
+++ b/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/token/generation/jwt/SignedJwtTokenGenerator.groovy
@@ -16,10 +16,12 @@
  */
 package grails.plugin.springsecurity.rest.token.generation.jwt
 
+import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.JWSSigner
 import com.nimbusds.jose.crypto.MACSigner
+import com.nimbusds.jose.crypto.RSASSASigner
 import com.nimbusds.jwt.JWT
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
@@ -38,16 +40,25 @@ class SignedJwtTokenGenerator extends AbstractJwtTokenGenerator implements Initi
 
     JWSSigner signer
 
+    RSAKeyProvider keyProvider
+
     JWSAlgorithm jwsAlgorithm
 
     @Override
     void afterPropertiesSet() throws Exception {
-        signer = new MACSigner(jwtSecret)
+        if (JWSAlgorithm.Family.RSA.contains(jwsAlgorithm)) {
+            signer = new RSASSASigner(keyProvider.privateKey)
+        } else {
+            signer = new MACSigner(jwtSecret)
+        }
     }
 
     @Override
     protected JWT generateAccessToken(JWTClaimsSet claimsSet) {
-        SignedJWT signedJWT = new SignedJWT(new JWSHeader(jwsAlgorithm), claimsSet)
+        JWSHeader header = new JWSHeader.Builder(jwsAlgorithm)
+                .type(JOSEObjectType.JWT)
+                .build()
+        SignedJWT signedJWT = new SignedJWT(header, claimsSet)
         signedJWT.sign(signer)
 
         return signedJWT

--- a/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/token/generation/jwt/StringRSAKeyProvider.groovy
+++ b/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/token/generation/jwt/StringRSAKeyProvider.groovy
@@ -1,0 +1,49 @@
+package grails.plugin.springsecurity.rest.token.generation.jwt;
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.InitializingBean
+
+import java.security.KeyFactory
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.spec.X509EncodedKeySpec
+
+/**
+ * Loads RSA public/private key's from configuration strings
+ */
+@Slf4j
+@CompileStatic
+class StringRSAKeyProvider implements RSAKeyProvider, InitializingBean {
+
+    /** Full path to the public key so that {@code new File(publicKeyPath).exists() == true} */
+    String publicKeyStr
+
+    /** Full path to the private key so that {@code new File(publicKeyPath).exists() == true} */
+    String privateKeyStr
+
+    RSAPublicKey publicKey
+    RSAPrivateKey privateKey
+
+    @Override
+    void afterPropertiesSet() throws Exception {
+        log.debug "Loading public/private key from DER files"
+        KeyFactory kf = KeyFactory.getInstance("RSA")
+
+        log.debug "Public key: ${publicKeyStr}"
+        if (publicKeyStr) {
+            def keyBytes = publicKeyStr.bytes
+            def spec = new X509EncodedKeySpec(keyBytes)
+            publicKey = kf.generatePublic(spec) as RSAPublicKey
+        }
+
+        log.debug "Private key: ${privateKeyStr}"
+        if (privateKeyStr) {
+            def keyBytes = privateKeyStr.bytes
+            def spec = new PKCS8EncodedKeySpec(keyBytes)
+            privateKey = kf.generatePrivate(spec) as RSAPrivateKey
+        }
+    }
+
+}

--- a/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/token/generation/jwt/StringRSAKeyProvider.groovy
+++ b/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/token/generation/jwt/StringRSAKeyProvider.groovy
@@ -19,6 +19,12 @@ import org.bouncycastle.util.io.pem.PemReader
 @CompileStatic
 class StringRSAKeyProvider implements RSAKeyProvider, InitializingBean {
 
+    private static final String BEGIN_PRIVATE = '-----BEGIN PRIVATE KEY-----'
+    private static final String END_PRIVATE = '-----END PRIVATE KEY-----'
+
+    private static final String BEGIN_PUBLIC = '-----BEGIN PUBLIC KEY-----'
+    private static final String END_PUBLIC = '-----END PUBLIC KEY-----'
+
     String publicKeyStr
     String privateKeyStr
 
@@ -45,12 +51,24 @@ class StringRSAKeyProvider implements RSAKeyProvider, InitializingBean {
         log.debug "Public key: ${publicKeyStr}"
 
         if (publicKeyStr) {
+            if (!publicKeyStr.startsWith(BEGIN_PUBLIC)) {
+                publicKeyStr = "${BEGIN_PUBLIC}\n${publicKeyStr}"
+            }
+            if (!publicKeyStr.endsWith(END_PUBLIC)) {
+                publicKeyStr = "${publicKeyStr}\n${END_PUBLIC}"
+            }
             def spec = new X509EncodedKeySpec(decodeKey(publicKeyStr))
             publicKey = kf.generatePublic(spec) as RSAPublicKey
         }
 
         log.debug "Private key: ${privateKeyStr}"
         if (privateKeyStr) {
+            if (!privateKeyStr.startsWith(BEGIN_PRIVATE)) {
+                privateKeyStr = "${BEGIN_PRIVATE}\n${privateKeyStr}"
+            }
+            if (!privateKeyStr.endsWith(END_PRIVATE)) {
+                privateKeyStr = "${privateKeyStr}\n${END_PRIVATE}"
+            }
             def spec = new PKCS8EncodedKeySpec(decodeKey(privateKeyStr))
             privateKey = kf.generatePrivate(spec) as RSAPrivateKey
         }


### PR DESCRIPTION
In this fork I added support for RSA256 algorithm. So far only symetric algorithm HMAC was supported. Thanks to support of RSA256, the plugin can be used togheter with other components based on oauth2 using JWT signed tokens. This is the standard approach for spring-boot based applications using spring-security-oauth2 library.