### PR TITLE
Migrate to Pac4J 2.0.0

### DIFF
--- a/spring-security-rest/build.gradle
+++ b/spring-security-rest/build.gradle
@@ -10,7 +10,7 @@ dependencyManagement {
 }
 
 ext {
-    pac4jVersion = '1.8.8'
+    pac4jVersion = '2.0.0'
 }
 
 dependencies {

--- a/spring-security-rest/grails-app/controllers/grails/plugin/springsecurity/rest/RestOauthController.groovy
+++ b/spring-security-rest/grails-app/controllers/grails/plugin/springsecurity/rest/RestOauthController.groovy
@@ -23,11 +23,10 @@ import grails.plugin.springsecurity.rest.token.rendering.AccessTokenJsonRenderer
 import grails.plugin.springsecurity.rest.token.storage.TokenStorageService
 import org.apache.commons.codec.binary.Base64
 import grails.core.GrailsApplication
-import org.pac4j.core.client.BaseClient
-import org.pac4j.core.client.RedirectAction
+import org.pac4j.core.client.IndirectClient
 import org.pac4j.core.context.J2EContext
 import org.pac4j.core.context.WebContext
-import org.pac4j.oauth.client.BaseOAuthClient
+import org.pac4j.core.redirect.RedirectAction
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.userdetails.User
 
@@ -53,10 +52,9 @@ class RestOauthController {
      * allows the frontend application to define the frontend callback URL on demand.
      */
     def authenticate(String provider, String callback) {
-        BaseOAuthClient client = restOauthService.getClient(provider)
+        IndirectClient client = restOauthService.getClient(provider)
         WebContext context = new J2EContext(request, response)
 
-        RedirectAction redirectAction = client.getRedirectAction(context, true)
         if (callback) {
             try {
                 if (Base64.isBase64(callback.getBytes())){
@@ -69,6 +67,7 @@ class RestOauthController {
             }
         }
 
+        RedirectAction redirectAction = client.getRedirectAction(context)
         log.debug "Redirecting to ${redirectAction.location}"
         redirect url: redirectAction.location
     }

--- a/spring-security-rest/src/test/groovy/grails/plugin/springsecurity/rest/RestOauthServiceTest.groovy
+++ b/spring-security-rest/src/test/groovy/grails/plugin/springsecurity/rest/RestOauthServiceTest.groovy
@@ -55,6 +55,7 @@ class RestOauthServiceTest extends Specification {
         assert client instanceof org.pac4j.oauth.client.CasOAuthWrapperClient
         assert client.key == providerConfig(provider).key
         assert client.secret == providerConfig(provider).secret
+        assert client.casOAuthUrl == providerConfig(provider).casOAuthUrl
 
     }
 


### PR DESCRIPTION
As title says it's migration to 2.0 branch of pac4j.

It simplify many aspects of oauth client creation for developers and shouldn't touch anyone, who used built-in providers (like google, facebook and others).