### PR TITLE
Refresh_token could be invalid if a user is no longer valid

### DIFF
--- a/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGrailsPlugin.groovy
+++ b/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGrailsPlugin.groovy
@@ -208,6 +208,7 @@ class SpringSecurityRestGrailsPlugin extends Plugin {
         }
         tokenStorageService(JwtTokenStorageService) {
             jwtService = ref('jwtService')
+            userDetailsService = ref('userDetailsService')
         }
 
         issuerClaimProvider(IssuerClaimProvider) {


### PR DESCRIPTION
The principal represented by the refresh_token should be checked if a new refresh_token is requested. Otherwise a removed user is still able to access the service with it's refresh_token. 

@see discussion on slack: 
https://grails.slack.com/archives/C07M0GTDE/p1501073982181566