### PR TITLE
Allow JSON requests to refreshToken

### DIFF
--- a/spring-security-rest/grails-app/controllers/grails/plugin/springsecurity/rest/RestOauthController.groovy
+++ b/spring-security-rest/grails-app/controllers/grails/plugin/springsecurity/rest/RestOauthController.groovy
@@ -118,12 +118,22 @@ class RestOauthController {
      */
     def accessToken() {
         String grantType = params['grant_type']
+        String refreshToken = params['refresh_token']
+        
+        request.withFormat {
+            json{
+                def data = request.JSON
+                grantType = data['grant_type']?:data['grantType']
+                refreshToken = data['refresh_token']?:data['refreshToken']
+            }
+        }
+        
         if (!grantType || grantType != 'refresh_token') {
             render status: HttpStatus.BAD_REQUEST, text: "Invalid grant_type"
             return
         }
 
-        String refreshToken = params['refresh_token']
+        
         log.debug "Trying to generate an access token for the refresh token: ${refreshToken}"
         if (refreshToken) {
             try {


### PR DESCRIPTION
Currently you can only post application/x-www-form-urlencoded for a token refresh, this PR allows JSON as an alternative request format. 

