### PR TITLE
Fix issue where a bean does not exist if plugin is disabled

### DIFF
--- a/spring-security-rest-gorm/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGormGrailsPlugin.groovy
+++ b/spring-security-rest-gorm/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGormGrailsPlugin.groovy
@@ -57,6 +57,11 @@ class SpringSecurityRestGormGrailsPlugin extends Plugin {
     }}
 
     void doWithApplicationContext() {
+        def conf = SpringSecurityUtils.securityConfig
+        if (!conf || !conf.active || !conf.rest.active) {
+            return
+        }
+
         applicationContext.getBean(RestAuthenticationProvider).useJwt = false
     }
 }

--- a/spring-security-rest-grailscache/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGrailsCacheGrailsPlugin.groovy
+++ b/spring-security-rest-grailscache/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGrailsCacheGrailsPlugin.groovy
@@ -59,6 +59,11 @@ class SpringSecurityRestGrailsCacheGrailsPlugin extends Plugin {
     }}
 
     void doWithApplicationContext() {
+        def conf = SpringSecurityUtils.securityConfig
+        if (!conf || !conf.active || !conf.rest.active) {
+            return
+        }
+
         applicationContext.getBean(RestAuthenticationProvider).useJwt = false
     }
 }

--- a/spring-security-rest-memcached/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestMemcachedGrailsPlugin.groovy
+++ b/spring-security-rest-memcached/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestMemcachedGrailsPlugin.groovy
@@ -78,6 +78,11 @@ class SpringSecurityRestMemcachedGrailsPlugin extends Plugin {
     }}
 
     void doWithApplicationContext() {
+        def conf = SpringSecurityUtils.securityConfig
+        if (!conf || !conf.active || !conf.rest.active) {
+            return
+        }
+
         applicationContext.getBean(RestAuthenticationProvider).useJwt = false
     }
 }

--- a/spring-security-rest-redis/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestRedisGrailsPlugin.groovy
+++ b/spring-security-rest-redis/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestRedisGrailsPlugin.groovy
@@ -60,6 +60,11 @@ class SpringSecurityRestRedisGrailsPlugin extends Plugin {
     }}
 
     void doWithApplicationContext() {
+        def conf = SpringSecurityUtils.securityConfig
+        if (!conf || !conf.active || !conf.rest.active) {
+            return
+        }
+
         applicationContext.getBean(RestAuthenticationProvider).useJwt = false
     }
 


### PR DESCRIPTION
This pull request fixes an issue where if Spring Security is disabled (i.e. for testing), then the plugin attempts to load a bean that does not exist.  The correct check exists in `doWithSpring`, but is missing in `doWithApplicationContext`.

```
org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'grails.plugin.springsecurity.rest.RestAuthenticationProvider' available
```