### PR TITLE
Bump spring core plugin version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 grailsVersion=4.0.0
-springSecurityCoreVersion=4.0.0.RC3
+springSecurityCoreVersion=4.0.5
 gradleWrapperVersion=4.9
 bintrayUser=alvarosanchez
 pluginPortalUser=alvaro.sanchez


### PR DESCRIPTION
An issue was found with the Spring security core plugin on the 22nd of November 2022
https://grails.org/blog/2022-11-22-ss-plugin-auth-cve.html

This is just a bump to the version used to prevent the plugin being affected.

Thanks,
James