### PR TITLE
use grails-gradle-plugin:6.2.1 for testapp profile

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ projectGroup=org.grails.plugins
 projectVersion=5.0.0-SNAPSHOT
 grailsVersion=6.1.1
 grailsGradlePluginVersion=6.1.1
+grailsGradlePluginForProfileVersion=6.2.1
 gradlePublishPlugin=1.3.0
 springSecurityCoreVersion=6.1.1
 pac4jVersion=5.7.2

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,6 +31,6 @@ include 'spring-security-rest-memcached'
 include 'spring-security-rest-redis'
 include 'spring-security-rest-grailscache'
 include 'spring-security-rest-gorm'
-// include 'spring-security-rest-testapp-profile' // See https://github.com/grails/grails-spring-security-rest/pull/521#issuecomment-2380242985 for why this is commented out
+include 'spring-security-rest-testapp-profile'
 include 'spring-security-rest-docs'
 

--- a/spring-security-rest-testapp-profile/build.gradle
+++ b/spring-security-rest-testapp-profile/build.gradle
@@ -1,3 +1,18 @@
+buildscript {
+    repositories {
+        mavenCentral()
+        maven { url "https://repo.grails.org/grails/core" }
+    }
+    dependencies {
+        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginForProfileVersion"
+    }
+}
+
+plugins {
+    id 'maven-publish'
+    id 'signing'
+}
+
 task generateProfileConfig () {
     copy {
         from 'profile.yml.tmpl'
@@ -15,5 +30,3 @@ task generateProfileConfig () {
         }
     }
 }
-
-compileProfile.dependsOn generateProfileConfig


### PR DESCRIPTION
now that grails-gradle-plugin:6.2.1 has been published, we can bring this back, in case anyone was using it

grailsGradlePluginForProfileVersion will be removed for 6.0.x branch which will use grails-gradle-plugin:7.0.0-SNAPSHOT for entire project